### PR TITLE
Offer CMakeLists.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,60 @@ Currently, there are two communication back-ends, one using SCIF (intra-node) an
 Example
 =======
 
-A simple example that introduces the HAM-Offload API can be found in [src/inner\_product_cpp](src/inner_product.cpp). 
+A simple example that introduces the HAM-Offload API can be found in [src/inner\_product_cpp](src/inner_product.cpp).
+
+Building with CMake
+=========================
+
+|                   | requirement                                                   | version          |
+|-------------------|---------------------------------------------------------------|------------------|
+|**compiler**       | c++ compiler                                                  | c++11 compatible |
+|**build system**   | [cmake](https://cmake.org)                                    | ≥ 3.2            |
+|**required libs**  | Boost Program Options from [boost.org](http://www.boost.org/) | ≥ 1.40           |
+
+Building and Installing Boost
+-----------------------------
+
+See the section `Building and Installing Boost` in `Boost.Build`.
+
+
+Building HAM-Offload
+--------------------
+
+1. Checkout the GitHub repository:
+
+	```
+	$ git clone https://github.com/noma/ham.git
+	```
+
+2. Create a build directory:
+
+	```terminal
+	$ cd ham # change into repository
+	$ mkdir build
+	$ cmake ../src -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=CC -DBUILD_SHARED_LIBS=OFF
+	```
+
+	* `-DCMAKE_BUILD_TYPE=Release` will do a release build (e.g. `-DNDEBUG`, `-O2`)
+	* `-DCMAKE_CXX_COMPILER=CC` specifies the compiler. On a CRAY-System you
+	  should use the `CC` wrapper, because it will have all MPI-related flags
+	  already set. You could also specify `g++`, `clang++` or `icpc`.
+	* `-DBUILD_SHARED_LIBS=OFF` will build ham as a static library (e.g. `libham_offload_mpi.a`).
+
+3. Build everything:
+
+	```
+	$ make -j 8 # do 8 builds in parallel
+	```
+	If nothing went wrong, the libraries are in `build`.
+	For each back-end, there are two libraries. The one with the `_explicit` suffix is intended for library authors, who need to explicitly initialise and finalise HAM-Offload.
+
+	|                           | <scif.h> found                                          | MPI found                                             |
+	|---------------------------|---------------------------------------------------------|-------------------------------------------------------|
+	| BUILD_SHARED_LIBS = True  | libham_offload_scif.so  libham_offload_scif_explicit.so | libham_offload_mpi.so  libham_offload_mpi_explicit.so |
+	| BUILD_SHARED_LIBS = False | libham_offload_scif.a  libham_offload_scif_explicit.a   | libham_offload_mpi.a  libham_offload_mpi_explicit.a   |
+
+4. You can now link or copy the libraries and headers either to your system or project, or just use them where they are (in which case you have to add their path to `LD_LIBRARY_PATH` environment variable).
 
 Building with Boost.Build
 =========================

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,16 +1,14 @@
 project(ham_library CXX)
 cmake_minimum_required(VERSION 3.2)
 
-set(HAM_ROOT "${CMAKE_SOURCE_DIR}/..")
-include_directories("${HAM_ROOT}/include/")
-
 find_package(Boost 1.40 COMPONENTS program_options REQUIRED)
 find_package(MPI)
 
 # Dependency libraries
 
 add_library (ham_cxx_std_11 INTERFACE)
-target_compile_features(ham_cxx_std_11 INTERFACE cxx_auto_type cxx_range_for cxx_variadic_templates)
+target_compile_features (ham_cxx_std_11 INTERFACE cxx_auto_type cxx_range_for cxx_variadic_templates)
+target_include_directories (ham_cxx_std_11 INTERFACE ${CMAKE_CURRENT_LIST_DIR}/../include/)
 
 add_library (boost_library INTERFACE)
 target_include_directories (boost_library INTERFACE ${Boost_INCLUDE_DIRS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,141 @@
+project(ham_library CXX)
+cmake_minimum_required(VERSION 3.2)
+
+set(HAM_ROOT "${CMAKE_SOURCE_DIR}/..")
+include_directories("${HAM_ROOT}/include/")
+
+find_package(Boost 1.40 COMPONENTS program_options REQUIRED)
+find_package(MPI)
+
+# Dependency libraries
+
+add_library (ham_cxx_std_11 INTERFACE)
+target_compile_features(ham_cxx_std_11 INTERFACE cxx_auto_type cxx_range_for cxx_variadic_templates)
+
+add_library (boost_library INTERFACE)
+target_include_directories (boost_library INTERFACE ${Boost_INCLUDE_DIRS})
+target_link_libraries (boost_library INTERFACE ${Boost_LIBRARIES})
+
+if (MPI_FOUND)
+    add_library (mpi_library INTERFACE)
+    target_include_directories (mpi_library INTERFACE ${MPI_CXX_INCLUDE_PATH})
+    target_compile_options (mpi_library INTERFACE ${MPI_CXX_COMPILE_FLAGS})
+    target_link_libraries (mpi_library INTERFACE ${MPI_CXX_LIBRARIES})
+endif ()
+
+find_file(SCIF_HEADER_FILE "scif.h")
+if (SCIF_HEADER_FILE)
+    set(SCIF_FOUND ON)
+    get_filename_component(SCIF_INCLUDE_DIR "${SCIF_HEADER_FILE}" DIRECTORY)
+    message(STATUS "Found SCIF: ${SCIF_HEADER_FILE}")
+
+    add_library (scif_library INTERFACE)
+    target_include_directories (scif_library INTERFACE ${SCIF_INCLUDE_DIR})
+else ()
+    message(STATUS "Could NOT find SCIF (missing: scif.h)")
+endif ()
+
+#### Libraries
+
+if (MPI_FOUND)
+    add_library (ham_offload_mpi # SHARED if BUILD_SHARED_LIBS = TRUE
+                 ham/offload/main.cpp
+                 ham/net/communicator.cpp
+                 ham/net/communicator_mpi.cpp
+                 ham/offload/runtime.cpp
+                 ham/offload/offload.cpp
+                 ham/util/cpu_affinity.cpp)
+    target_compile_definitions (ham_offload_mpi PUBLIC -DHAM_COMM_MPI=1)
+    target_link_libraries (ham_offload_mpi PUBLIC ham_cxx_std_11 mpi_library boost_library)
+
+    add_library (ham_offload_mpi_explicit # SHARED if BUILD_SHARED_LIBS = TRUE
+                 ham/offload/main_explicit.cpp
+                 ham/net/communicator.cpp
+                 ham/net/communicator_mpi.cpp
+                 ham/offload/runtime.cpp
+                 ham/offload/offload.cpp
+                 ham/util/cpu_affinity.cpp)
+    target_compile_definitions (ham_offload_mpi_explicit PUBLIC -DHAM_COMM_MPI=1 -DHAM_EXPLICIT=1)
+    target_link_libraries (ham_offload_mpi_explicit PUBLIC ham_cxx_std_11 mpi_library boost_library)
+endif ()
+
+#### Benchmarks
+
+# Explicit targets (not built by default)
+add_executable (benchmark_intel_leo EXCLUDE_FROM_ALL benchmark_intel_leo.cpp)
+target_link_libraries (benchmark_intel_leo)
+
+if (MPI_FOUND)
+    add_executable (benchmark_ham_offload_mpi benchmark_ham_offload.cpp)
+    target_link_libraries (benchmark_ham_offload_mpi ham_offload_mpi)
+endif()
+
+#### Examples/Tests
+add_executable (active_msgs active_msgs.cpp)
+target_link_libraries (active_msgs ham_cxx_std_11)
+
+if (MPI_FOUND)
+    add_executable (ham_offload_test_mpi ham_offload.cpp)
+    target_link_libraries (ham_offload_test_mpi ham_offload_mpi)
+
+    add_executable (ham_offload_test_explicit_mpi ham_offload_explicit.cpp)
+    target_link_libraries (ham_offload_test_explicit_mpi ham_offload_mpi_explicit)
+
+    add_executable (inner_product_mpi inner_product.cpp)
+    target_link_libraries (inner_product_mpi ham_offload_mpi)
+
+    add_executable (test_data_transfer_mpi test_data_transfer.cpp)
+    target_link_libraries (test_data_transfer_mpi ham_offload_mpi)
+
+    add_executable (test_argument_transfer_mpi test_argument_transfer.cpp)
+    target_link_libraries (test_argument_transfer_mpi ham_offload_mpi)
+endif()
+
+#### Libraries
+
+if (SCIF_FOUND)
+    add_library (ham_offload_scif # SHARED if BUILD_SHARED_LIBS = TRUE
+                 ham/offload/main.cpp
+                 ham/net/communicator.cpp
+                 ham/net/communicator_scif.cpp
+                 ham/offload/runtime.cpp
+                 ham/offload/offload.cpp
+                 ham/util/cpu_affinity.cpp)
+    target_compile_definitions (ham_offload_scif PUBLIC -DHAM_COMM_SCIF=1)
+    target_link_libraries (ham_offload_scif_explicit PUBLIC ham_cxx_std_11 boost_library scif_library)
+
+    add_library (ham_offload_scif_explicit # SHARED if BUILD_SHARED_LIBS = TRUE
+                 ham/offload/main_explicit.cpp
+                 ham/net/communicator.cpp
+                 ham/net/communicator_scif.cpp
+                 ham/offload/runtime.cpp
+                 ham/offload/offload.cpp
+                 ham/util/cpu_affinity.cpp)
+    target_compile_definitions (ham_offload_scif_explicit PUBLIC -DHAM_COMM_SCIF=1 -DHAM_EXPLICIT=1)
+    target_link_libraries (ham_offload_scif_explicit PUBLIC ham_cxx_std_11 boost_library scif_library)
+endif ()
+
+#### Benchmarks
+if (SCIF_FOUND)
+    add_executable (benchmark_ham_offload_scif benchmark_ham_offload.cpp)
+    target_link_libraries (benchmark_ham_offload_scif ham_offload_scif)
+endif()
+
+#### Examples/Tests
+
+if (SCIF_FOUND)
+    add_executable (ham_offload_test_scif ham_offload.cpp)
+    target_link_libraries (ham_offload_test_scif ham_offload_scif)
+
+    add_executable (ham_offload_test_explicit_scif ham_offload_explicit.cpp)
+    target_link_libraries (ham_offload_test_explicit_scif ham_offload_scif_explicit)
+
+    add_executable (inner_product_scif inner_product.cpp)
+    target_link_libraries (inner_product_scif ham_offload_scif)
+
+    add_executable (test_data_transfer_scif test_data_transfer.cpp)
+    target_link_libraries (test_data_transfer_scif ham_offload_scif)
+
+    add_executable (test_argument_transfer_scif test_argument_transfer.cpp)
+    target_link_libraries (test_argument_transfer_scif ham_offload_scif)
+endif()


### PR DESCRIPTION
fixes part of #3; no deprecation, yet

SCIF part is completely untested, because I don't have access to it.

I set boost1.40 as minimum version. Do you prefer to require a more recent versions?

I'm not sure where you want to have the CMakeLists.txt file.