### PR TITLE
make buffer_ptr::get and buffer_ptr::node const

### DIFF
--- a/include/ham/net/communicator_mpi.hpp
+++ b/include/ham/net/communicator_mpi.hpp
@@ -27,9 +27,9 @@ public:
 	buffer_ptr();
 	buffer_ptr(T* ptr, node_t node) : ptr_(ptr), node_(node) { }
 
-	T* get() { return ptr_; }
-	node_t node() { return node_; }
-	
+	T* get() const { return ptr_; }
+	node_t node() const { return node_; }
+
 	// element access
 	T& operator [] (size_t i);
 


### PR DESCRIPTION
In SCIF this was already declared as const:

https://github.com/noma/ham/blob/5649c04291336e0df172734ca8631d7be3020dbd/include/ham/net/communicator_scif.hpp#L41-L44
